### PR TITLE
Value conversion into convars

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_hd_knife.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_hd_knife.lua
@@ -17,11 +17,11 @@ SWEP.ViewModel = "models/weapons/cstrike/c_knife_t.mdl"
 SWEP.WorldModel = "models/weapons/w_knife_t.mdl"
 SWEP.UseHands = true 
 
-SWEP.Primary.Damage = 60
+SWEP.Primary.Damage = GetConVar("ttt2_hdn_knife_damage"):GetInt()
 SWEP.Primary.ClipSize = -1
 SWEP.Primary.DefaultClip = -1
 SWEP.Primary.Automatic = true 
-SWEP.Primary.Delay = 1
+SWEP.Primary.Delay = GetConVar("ttt2_hdn_knife_swing"):GetInt()
 SWEP.Primary.Ammo = "none"
 
 SWEP.Secondary.ClipSize = -1

--- a/lua/terrortown/autorun/shared/sh_hd_convar.lua
+++ b/lua/terrortown/autorun/shared/sh_hd_convar.lua
@@ -1,10 +1,31 @@
-CreateConVar("ttt2_hdn_knife_delay", "15", {FCVAR_ARCHIVE, FCVAR_NOTIFY})
-CreateConVar("ttt2_hdn_nade_delay", "30", {FCVAR_ARCHIVE, FCVAR_NOTIFY})
-CreateConVar("ttt2_hdn_stun_duration", "5", {FCVAR_ARCHIVE, FCVAR_NOTIFY})
+CreateConVar("ttt2_hdn_knife_damage", "60", {FCVAR_ARCHIVE, FCVAR_NOTIFY}) -- Primary attack damage for knife, require restart
+CreateConVar("ttt2_hdn_knife_swing", "1", {FCVAR_ARCHIVE, FCVAR_NOTIFY}) -- Primary attack speed for knife, requires restart
+CreateConVar("ttt2_hdn_knife_delay", "15", {FCVAR_ARCHIVE, FCVAR_NOTIFY}) -- Recharge time for thrown knife in seconds
+CreateConVar("ttt2_hdn_nade_delay", "30", {FCVAR_ARCHIVE, FCVAR_NOTIFY}) -- Recharge time for stun grenade in seconds
+CreateConVar("ttt2_hdn_health_bonus", "8", {FCVAR_ARCHIVE, FCVAR_NOTIFY}) -- Bonus health gained per player 
+CreateConVar("ttt2_hdn_health_max", "300", {FCVAR_ARCHIVE, FCVAR_NOTIFY}) -- Maximun ammount of health the player can have
+CreateConVar("ttt2_hdn_speed", "1.6", {FCVAR_ARCHIVE, FCVAR_NOTIFY}) -- Movement Bonus
 
 hook.Add("TTTUlxDynamicRCVars", "ttt2_hdn_ulx_convars", function(tbl)
     tbl[ROLE_HIDDEN] = tbl[ROLE_HIDDEN] or {}
-
+        
+    table.insert(tbl[ROLE_HIDDEN], {
+        cvar = "ttt2_hdn_knife_damage",
+        slider = true,
+        min = 1,
+        max = 100,
+        desc = "ttt2_hdn_knife_damage (def. 60)"
+    })
+        
+	table.insert(tbl[ROLE_HIDDEN], {
+        cvar = "ttt2_hdn_knife_swing",
+        slider = true,
+        min = 1,
+        max = 2,
+		decimal = 1,
+        desc = "ttt2_hdn_knife_swing (def. 1)"
+    })
+        
     table.insert(tbl[ROLE_HIDDEN], {
         cvar = "ttt2_hdn_knife_delay",
         slider = true,
@@ -27,5 +48,30 @@ hook.Add("TTTUlxDynamicRCVars", "ttt2_hdn_ulx_convars", function(tbl)
         min = 1,
         max = 30,
         desc = "ttt2_hdn_stun_duration (def. 5)"
+    })
+        
+    table.insert(tbl[ROLE_HIDDEN], {
+        cvar = "ttt2_hdn_health_bonus",
+        slider = true,
+        min = 1,
+        max = 50,
+        desc = "ttt2_hdn_health_bonus (def. 8)"
+    })
+	
+	table.insert(tbl[ROLE_HIDDEN], {
+        cvar = "ttt2_hdn_health_max",
+        slider = true,
+        min = 100,
+        max = 500,
+        desc = "ttt2_hdn_health_max (def. 300)"
+    })
+	
+	table.insert(tbl[ROLE_HIDDEN], {
+        cvar = "ttt2_hdn_speed",
+        slider = true,
+        min = 1,
+        max = 2,
+		decimal = 1,
+        desc = "ttt2_hdn_speed_max (def. 1.6)"
     })
 end)

--- a/lua/terrortown/autorun/shared/sh_hd_handler.lua
+++ b/lua/terrortown/autorun/shared/sh_hd_handler.lua
@@ -316,7 +316,7 @@ if SERVER then
     hook.Add("TTTPlayerSpeedModifier", "HiddenSpeedBonus", function(ply, _, _, speedMod)
         if ply:GetSubRole() ~= ROLE_HIDDEN or not ply:GetNWBool("ttt2_hd_stalker_mode") then return end
 
-        speedMod[1] = speedMod[1] * 1.6
+        speedMod[1] = speedMod[1] * GetConVar("ttt2_hdn_speed"):GetInt()
     end)
 
     hook.Add("TTT2StaminaRegen", "HiddenStaminaMod", function(ply, stamMod)

--- a/lua/terrortown/entities/roles/hidden/shared.lua
+++ b/lua/terrortown/entities/roles/hidden/shared.lua
@@ -58,9 +58,9 @@ if SERVER then
         if ply:GetNWBool("ttt2_hd_stalker_mode", false) then return end
 
         if key == IN_RELOAD then
-            local c = (#util.GetAlivePlayers() - 1) * 8
-            local hp = math.Clamp(ply:Health() + c, ply:Health(), 300)
-            local max_hp = math.Clamp(100 + c, ply:GetMaxHealth(), 300)
+            local c = (#util.GetAlivePlayers() - 1) * GetConVar("ttt2_hdn_health_bonus"):GetInt()
+            local hp = math.Clamp(ply:Health() + c, ply:Health(), GetConVar("ttt2_hdn_health_max"):GetInt())
+            local max_hp = math.Clamp(100 + c, ply:GetMaxHealth(), GetConVar("ttt2_hdn_health_max"):GetInt())
             ply:SetMaxHealth(max_hp)
             ply:SetHealth(hp)
             ply:SetStalkerMode(true)


### PR DESCRIPTION
Although the role is perfect enough on its own, some values still require fine-tuning.
Variables such as the knife's primary attack speed and damage, along with the role's speed bonus, health maximum, and bonus have been changed to rely on convar values which grants both server operators and developers easier time to balance the role.
I have no idea what values I suggested during the testing period, but it seems like it's not balanced for usage on large servers, this should relay the issue from the dev to the server op.